### PR TITLE
WORM bug fixes

### DIFF
--- a/app/Commands/MigrateCommand.php
+++ b/app/Commands/MigrateCommand.php
@@ -677,6 +677,8 @@ class MigrateCommand extends Command
         // Replace the s3 bucket name
         $this->stringReplaceS3BucketName($sourceBucket, $targetBucket, $targetSiteURL, $containerExecCommand, $blogID);
 
+        $this->info('=> AWS s3 bucket sync');
+
         passthru("kubectl exec -it -n hale-platform-$source $servicePodName -- bin/sh -c \"aws s3 sync s3://$sourceBucket/$uploadsDir s3://$targetBucket/$uploadsDir --acl=public-read\"");
     }
 

--- a/app/Commands/MigrateCommand.php
+++ b/app/Commands/MigrateCommand.php
@@ -929,7 +929,7 @@ class MigrateCommand extends Command
 
         // Search and replace only on the correct URL and blog ID if is single site migration
         if ($this->blogID !== null) {
-            $urlFlag = "--url=$domain 'wp_$siteID*' --all-tables-with-prefix";
+            $urlFlag = "--url=$domain 'wp_{$siteID}_*' --all-tables-with-prefix";
         } else {
             $urlFlag = "--url=$domain";
         }

--- a/app/Commands/MigrateCommand.php
+++ b/app/Commands/MigrateCommand.php
@@ -897,7 +897,6 @@ class MigrateCommand extends Command
 
          // Search and replace only on the correct URL and blog ID if is single site migration
         if ($this->blogID !== null) {
-
             // Handles whether you are migrating to a domain on prod or the hale-platform infrastructure domain
             // as we can have both types on production.
             if ($domain !== null) {
@@ -905,7 +904,6 @@ class MigrateCommand extends Command
             } else {
                 $urlFlag = "--url=$domainPath 'wp_{$siteID}_*' --all-tables-with-prefix";
             }
-            
         } else {
             $urlFlag = "--url=$domainPath";
         }

--- a/app/Commands/MigrateCommand.php
+++ b/app/Commands/MigrateCommand.php
@@ -448,7 +448,7 @@ class MigrateCommand extends Command
         $containerExecCommand = $this->getExecCommand($env);
 
         # Get Single Blog Table Names
-        $tableNames = rtrim(shell_exec("$containerExecCommand wp db tables 'wp_$blogID*' --all-tables-with-prefix --format=csv"));
+        $tableNames = rtrim(shell_exec("$containerExecCommand wp db tables 'wp_{$blogID}_*' --all-tables-with-prefix --format=csv"));
 
         if (count(explode(",", $tableNames)) < 10) {
             $this->info('Not all blog tables found');
@@ -559,7 +559,7 @@ class MigrateCommand extends Command
         $containerExecCommand = $this->getExecCommand($env);
 
         if ($this->blogID !== null) {
-            $urlFlag = "--url=$targetSiteURL 'wp_{$blogID}_*' --all-tables-with-prefix --dry-run";
+            $urlFlag = "--url=$targetSiteURL 'wp_{$blogID}_*' --all-tables-with-prefix";
         } else {
             $urlFlag = "--url=$sourceSiteURL";
         }
@@ -822,7 +822,7 @@ class MigrateCommand extends Command
         $targetSiteURL = "hale.docker";
 
         if ($this->blogID !== null) {
-            $urlFlag = "--url=$targetSiteURL";
+            $urlFlag = "--url=$domainPath 'wp_{$siteID}_*' --all-tables-with-prefix";
         } else {
             $urlFlag = "--url=$sourceSiteURL";
         }
@@ -895,7 +895,7 @@ class MigrateCommand extends Command
 
          // Search and replace only on the correct URL and blog ID if is single site migration
         if ($this->blogID !== null) {
-            $urlFlag = "--url=$domainPath 'wp_$siteID*' --all-tables-with-prefix";
+            $urlFlag = "--url=$domainPath 'wp_{$siteID}_*' --all-tables-with-prefix";
         } else {
             $urlFlag = "--url=$domainPath";
         }
@@ -963,7 +963,7 @@ class MigrateCommand extends Command
     {
 
         if ($this->blogID !== null) {
-            $urlFlag = "--url=$targetSiteURL 'wp_{$blogID}_*' --all-tables-with-prefix --dry-run";
+            $urlFlag = "--url=$targetSiteURL 'wp_{$blogID}_*' --all-tables-with-prefix";
         } else {
             $urlFlag = "--url=$sourceSiteURL";
         }

--- a/app/Commands/MigrateCommand.php
+++ b/app/Commands/MigrateCommand.php
@@ -822,7 +822,7 @@ class MigrateCommand extends Command
         $targetSiteURL = "hale.docker";
 
         if ($this->blogID !== null) {
-            $urlFlag = "--url=$domainPath 'wp_{$siteID}_*' --all-tables-with-prefix";
+            $urlFlag = "--url=$domainPath 'wp_{$this->blogID}_*' --all-tables-with-prefix";
         } else {
             $urlFlag = "--url=$sourceSiteURL";
         }

--- a/app/Commands/MigrateCommand.php
+++ b/app/Commands/MigrateCommand.php
@@ -971,7 +971,7 @@ class MigrateCommand extends Command
         }
 
         $command = "$containerExecCommand wp search-replace $sourceBucket $targetBucket $urlFlag --network --precise --skip-columns=guid --report-changed-only --recurse-objects";
-        $this->info("Run s3 bucket string replace: $sourceBucket => $targetBucket ");
+        $this->info("Run s3 bucket string replace: $sourceBucket with $targetBucket ");
         passthru($command);
     }
 }

--- a/app/Providers/SiteList.php
+++ b/app/Providers/SiteList.php
@@ -35,6 +35,12 @@ $sites = [
         "path" => "vc",
     ],
 
+    "lob" => [
+        "blogID" => 7,
+        "domain" => "layobservers.org",
+        "path" => "lo",
+    ],
+
     "cym" => [
         "blogID" => 11,
         "domain" => "magistrates.judiciary.uk/cymraeg",
@@ -53,16 +59,70 @@ $sites = [
         "path" => "imb",
     ],
 
+    "vaw" => [
+        "blogID" => 15,
+        "domain" => "victimandwitnessinformation.org.uk",
+        "path" => "vw",
+    ],
+
     "icr" => [
         "blogID" => 16,
         "domain" => "icrir.independent-inquiry.uk",
         "path" => "icrir",
     ],
 
+    "ppj" => [
+        "blogID" => 18,
+        "domain" => "prisonandprobationjobs.gov.uk",
+        "path" => "ppj",
+    ],
+
+    "npm" => [
+        "blogID" => 23,
+        "domain" => "nationalpreventivemechanism.org.uk",
+        "path" => "npm",
+    ],
+
     "brh" => [
         "blogID" => 29,
         "domain" => "brookhouseinquiry.org.uk",
         "path" => "brookhouse",
+    ],
+
+    "lwc" => [
+        "blogID" => 30,
+        "domain" => "lawcom.gov.uk",
+        "path" => "lc",
+    ],
+
+    "jjb" => [
+        "blogID" => 31,
+        "domain" => "jobs.justice.gov.uk",
+        "path" => "jj",
+    ],
+
+    "ppo" => [
+        "blogID" => 34,
+        "domain" => "ppo.gov.uk",
+        "path" => "ppo",
+    ],
+
+    "sif" => [
+        "blogID" => 36,
+        "domain" => "sifocc.org",
+        "path" => "sifocc",
+    ],
+
+    "mib" => [
+        "blogID" => 37,
+        "domain" => "my.imb.org.uk",
+        "path" => "imbmembers-leg",
+    ],
+
+    "mlo" => [
+        "blogID" => 39,
+        "domain" => "members.layobservers.org",
+        "path" => "layobservers-members",
     ],
     ];
 


### PR DESCRIPTION
Bug fixes
* Database find and replace leak bug. Wildcard regex on wp db table blog id, meant that more than one specified blog could get caught up in the find and replace. For example, say you migrated blog id 2, you could all get blog id 22 or 222. Fix makes it so you only use exact blog id and wildcard only happens after the underscore.
* BlogID var added to s3 bucket replacement so it correctly syncs only that specific blog id when migrating a specific blog.
* Added conditional for non-prod to prod domain write. When migrating from non-prod (like staging) to prod, there was no logic in place to distinguish between the infrastructure domain (ie hale-platform-prod....) or the public domain. 
* The order of our find and replace command seems to matter. We've mixed up the order in several places. After reviewing all the times we use find and replace, some where not working correctly unless structured in the same way. I settled on the following order throughout `wp search-replace '$domainPath' 'https://$domain' $urlFlag ...`.
* Added newly create public domains missing from hardcoded site list.