### PR TITLE
Add import to local Docker container functionality

### DIFF
--- a/app/Commands/Db/ExportCommand.php
+++ b/app/Commands/Db/ExportCommand.php
@@ -45,6 +45,11 @@ class ExportCommand extends Command
 
         $exportDatabase = new ExportDatabase($target, $sqlfile, $blogID);
 
+        if ($target === 'local') {
+            echo 'Error: Worm cannot export local database. Functionality not added.' . PHP_EOL;
+            exit;
+        }
+
         if (is_null($blogID)) {
             $exportDatabase->runExportMultisite();
         }

--- a/app/Commands/Db/ImportCommand.php
+++ b/app/Commands/Db/ImportCommand.php
@@ -111,13 +111,8 @@ class ImportCommand extends Command
         $target = $this->argument('target');
 
         if ($target === 'prod') {
-            $proceed = $this->ask('### WARNING ### You are running a command against prod. Do you wish to proceed? y/n');
-
-            // If not "yes", then exit.
-            if ($proceed !== 'yes' && $proceed !== 'y') {
-                $this->info("Command canceled. Exiting task.");
-                exit(0);
-            }
+            echo 'You cannot import to prod. Functionality not yet added.' . PHP_EOL;
+            exit;
         }
     }
 }

--- a/app/Commands/ImportDatabase.php
+++ b/app/Commands/ImportDatabase.php
@@ -124,6 +124,8 @@ class ImportDatabase
     public function runDatabaseImport()
     {
         $this->copyDatabaseToContainer();
+
+        die();
         $this->executeDbImportCommand();
         $this->removeSqlFileFromContainer();
         $this->replaceDatabaseURLs();

--- a/app/Commands/ImportDatabase.php
+++ b/app/Commands/ImportDatabase.php
@@ -227,11 +227,11 @@ class ImportDatabase
             // No need to sync S3 buckets for the local environment
             return;
         }
-    
+
         // Sync S3 buckets between source and target environments
         $this->kubernetesObject->syncS3Buckets($this->target, $this->source, $this->blogID);
     }
-    
+
     /**
      * Perform string replacement of S3 bucket names in the WordPress installation.
      */
@@ -250,27 +250,28 @@ class ImportDatabase
     /**
      * Performs domain rewrite for non-production environments.
      * This method swaps the production domain with a non-production domain.
-     * 
+     *
      * @return void
      */
-    protected function applyDomainRewriteNonProd() {
+    protected function applyDomainRewriteNonProd()
+    {
         // Check if the target environment is production; if so, return early
         if ($this->target === 'prod') {
             return;
         }
-        
+
         // Retrieve the Kubernetes exec command for the target environment
         $containerExecCommand = $this->kubernetesObject->getExecCommand($this->target);
-        
+
         // Retrieve site information from the container object
         $sites = $this->containerObject->get('sites');
-        
+
         // Informational text for the operation
         $infoText = "[*] Rewrite prod domain with a non-prod domain" . PHP_EOL;
-        
+
         // Output the informational text
         echo $infoText;
-        
+
         // Loop through each site in our hardcoded domain site list and rewrite urls
         foreach ($sites as $site) {
             $domain = $site['domain'];
@@ -316,9 +317,9 @@ class ImportDatabase
         $command .= " --network";
         $command .= " --skip-columns=guid";
         $command .= " --report-changed-only";
-            
+
         passthru($command, $status);
-    
+
         // Check if the command failed
         if ($status !== 0) {
             // An error occurred, handle it here
@@ -332,7 +333,7 @@ class ImportDatabase
 
         // 3. Path rewrite
         $this->wordpressObject->replaceDatabasePath($this->target, $sitePath, $siteID);
-    
+
         // Switch plugins on or off depending on environment
         $status = ($this->target === 'local' || $this->target === 'prod') ? 'deactivate' : 'activate';
 

--- a/app/Commands/ImportDatabase.php
+++ b/app/Commands/ImportDatabase.php
@@ -4,6 +4,8 @@ namespace App\Commands;
 
 use App\Helpers\Kubernetes;
 use App\Helpers\Wordpress;
+use App\Helpers\EnvUtils;
+use Illuminate\Container\Container;
 
 /**
  * Class ImportDatabase
@@ -86,6 +88,21 @@ class ImportDatabase
     protected $wordpressObject;
 
     /**
+     * An instance of the EnvUtils helper class.
+     *
+     * @var envUtilsObject
+     */
+    protected $envUtilsObject;
+
+    /**
+     * An instance of the Container site list class.
+     *
+     * @var Container
+     */
+    protected $containerObject;
+
+
+    /**
      * Constructor for the ImportDatabase class.
      *
      * Initializes an instance of the ImportDatabase class with the provided parameters, such as the target environment,
@@ -109,6 +126,8 @@ class ImportDatabase
         $this->s3sync = $s3sync;
         $this->kubernetesObject = new Kubernetes();
         $this->wordpressObject = new Wordpress();
+        $this->envUtilsObject = new EnvUtils();
+        $this->containerObject = Container::getInstance();
         $this->containerExec = $this->kubernetesObject->getExecCommand($target);
         $this->podName = $this->kubernetesObject->getPodName($target, "wordpress");
     }
@@ -124,11 +143,10 @@ class ImportDatabase
     public function runDatabaseImport()
     {
         $this->copyDatabaseToContainer();
-
-        die();
         $this->executeDbImportCommand();
         $this->removeSqlFileFromContainer();
         $this->replaceDatabaseURLs();
+        $this->applyDomainRewriteNonProd();
 
         if ($this->s3sync === 'true') {
             $this->syncS3Buckets();
@@ -152,6 +170,8 @@ class ImportDatabase
     protected function executeDbImportCommand()
     {
         $command = "$this->containerExec wp db import $this->fileName";
+
+        echo '[*] Run import' . PHP_EOL;
 
         // Execute the kubectl cp command
         passthru($command, $status);
@@ -193,20 +213,129 @@ class ImportDatabase
 
     /**
      * Sync S3 buckets between source and target environments.
+     *
+     * This function syncs S3 buckets between source and target environments using the KubernetesObject's syncS3Buckets method.
+     * It checks if the target environment is 'local' and returns early if so, as no synchronization is needed for the local environment.
+     * Otherwise, it invokes the syncS3Buckets method to perform the synchronization.
+     *
+     * @return void
      */
     protected function syncS3Buckets()
     {
+        // Check if the target environment is 'local'
+        if ($this->target == 'local') {
+            // No need to sync S3 buckets for the local environment
+            return;
+        }
+    
+        // Sync S3 buckets between source and target environments
         $this->kubernetesObject->syncS3Buckets($this->target, $this->source, $this->blogID);
     }
-
+    
     /**
      * Perform string replacement of S3 bucket names in the WordPress installation.
      */
     protected function replaceS3BucketNames()
     {
+        if ($this->target == 'local') {
+            return;
+        }
+
         $targetBucket = $this->kubernetesObject->getBucketName($this->target);
         $sourceBucket = $this->kubernetesObject->getBucketName($this->source);
 
         $this->wordpressObject->stringReplaceS3BucketName($targetBucket, $sourceBucket, $this->target, $this->blogID);
+    }
+
+    /**
+     * Performs domain rewrite for non-production environments.
+     * This method swaps the production domain with a non-production domain.
+     * 
+     * @return void
+     */
+    protected function applyDomainRewriteNonProd() {
+        // Check if the target environment is production; if so, return early
+        if ($this->target === 'prod') {
+            return;
+        }
+        
+        // Retrieve the Kubernetes exec command for the target environment
+        $containerExecCommand = $this->kubernetesObject->getExecCommand($this->target);
+        
+        // Retrieve site information from the container object
+        $sites = $this->containerObject->get('sites');
+        
+        // Informational text for the operation
+        $infoText = "[*] Rewrite prod domain with a non-prod domain" . PHP_EOL;
+        
+        // Output the informational text
+        echo $infoText;
+        
+        // Loop through each site in our hardcoded domain site list and rewrite urls
+        foreach ($sites as $site) {
+            $domain = $site['domain'];
+            $sitePath = $site['path'];
+            $siteID = $site['blogID'];
+
+            // Single site import: Run the rewrite code once for the matching single site and finish
+            if ($this->blogID !== null && $this->blogID === $siteID) {
+                $this->performDomainRewriteNonProd($domain, $sitePath, $siteID);
+            }
+
+            // Multisite import: If no blog ID is being used, migrate the entire site without restrictions
+            if ($this->blogID === null) {
+                $this->performDomainRewriteNonProd($domain, $sitePath, $siteID);
+            }
+        }
+    }
+
+    /**
+     * Perform domain rewrite prod to non-prod
+     *
+     * @param string $domain The domain of the site.
+     * @param string $sitePath The path of the site.
+     * @param string $containerExecCommand The command to execute in the container.
+     * @param int $siteID The ID of the site.
+     * @return void
+     */
+    protected function performDomainRewriteNonProd(string $domain, string $sitePath, int $siteID)
+    {
+        // Get either the hale.docker url or the CP url depending on the target
+        $nonProdDomain = $this->envUtilsObject->getNonProdDomain($this->target);
+
+        $newURL = $nonProdDomain . "/" . $sitePath;
+
+        echo PHP_EOL . 'Domain: ' . $domain . PHP_EOL;
+
+        // These 3 rewrites need to stay here in the loop
+
+        // 1. Search and replace rewrite
+        // Use siteID not blogID, so that only that domain is targeted in the rewrite
+        $command = "$this->containerExec wp search-replace 'https://$domain' 'https://$newURL'";
+        $command .= " --all-tables-with-prefix 'wp_{$siteID}_*'";
+        $command .= " --network";
+        $command .= " --skip-columns=guid";
+        $command .= " --report-changed-only";
+            
+        passthru($command, $status);
+    
+        // Check if the command failed
+        if ($status !== 0) {
+            // An error occurred, handle it here
+            throw new \InvalidArgumentException(
+                "Error: domain search and replace failed: \n$command"
+            );
+        }
+
+        // 2. Domain rewrite
+        $this->wordpressObject->replaceDatabaseDomain($this->target, $nonProdDomain, $siteID);
+
+        // 3. Path rewrite
+        $this->wordpressObject->replaceDatabasePath($this->target, $sitePath, $siteID);
+    
+        // Switch plugins on or off depending on environment
+        $status = ($this->target === 'local' || $this->target === 'prod') ? 'deactivate' : 'activate';
+
+        $this->wordpressObject->modifyPluginStatus($this->target, $status, 'wp-force-login', $nonProdDomain);
     }
 }

--- a/app/Commands/MigrateCommand.php
+++ b/app/Commands/MigrateCommand.php
@@ -584,8 +584,8 @@ class MigrateCommand extends Command
      */
     private function nonProductionDatabaseDomainRewrite($env, array $sites, $blogID)
     {
+        $infoMsg = "[*] Rewrite domains, prod to non-prod domain" . PHP_EOL;
 
-        $nonProdDBDomainRewriteText = "Run domain rewrite to swap prod domain with a non-prod domain.";
         $containerExecCommand = $this->getExecCommand($env);
 
         foreach ($sites as $site) {
@@ -595,13 +595,13 @@ class MigrateCommand extends Command
 
             // Only run the rewrite code once and for the matching single site and finish
             if ($this->blogID !== null && $blogID === $siteID) {
-                $this->info($nonProdDBDomainRewriteText);
+                $this->info($infoMsg);
                 $this->performDomainRewriteNonProd($domain, $sitePath, $containerExecCommand, $siteID);
             }
 
             // If we have no blog id being used we are migrating a whole site so loop without restrictions
             if ($this->blogID === null) {
-                $this->info($nonProdDBDomainRewriteText);
+                $this->info($infoMsg);
                 $this->performDomainRewriteNonProd($domain, $sitePath, $containerExecCommand, $siteID);
             }
         }
@@ -977,7 +977,9 @@ class MigrateCommand extends Command
         }
 
         $command = "$containerExecCommand wp search-replace $sourceBucket $targetBucket $urlFlag --network --precise --skip-columns=guid --report-changed-only --recurse-objects";
-        $this->info("Run s3 bucket string replace: $sourceBucket with $targetBucket ");
+        
+        echo "[*] Run s3 bucket string replace: $sourceBucket with $targetBucket " . PHP_EOL;
+
         passthru($command);
     }
 }

--- a/app/Commands/MigrateCommand.php
+++ b/app/Commands/MigrateCommand.php
@@ -977,7 +977,7 @@ class MigrateCommand extends Command
         }
 
         $command = "$containerExecCommand wp search-replace $sourceBucket $targetBucket $urlFlag --network --precise --skip-columns=guid --report-changed-only --recurse-objects";
-        
+
         echo "[*] Run s3 bucket string replace: $sourceBucket with $targetBucket " . PHP_EOL;
 
         passthru($command);

--- a/app/Helpers/Docker.php
+++ b/app/Helpers/Docker.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace App\Helpers;
 
-class Docker 
+class Docker
 {
     /**
      * Constructs the docker cp command to copy a file from a Docker container with retries.
@@ -10,10 +11,11 @@ class Docker
      * @param string $fileName      File name.
      * @return string              The constructed docker cp command.
      */
-    public function buildDockerCpCommand($filePath, $fileName) {
+    public function buildDockerCpCommand($filePath, $fileName)
+    {
         // Set the base docker cp command
         $command = "docker cp";
-        
+
         // Append options to the command
         $command .= " $filePath wordpress:/var/www/html/$fileName";
 

--- a/app/Helpers/Docker.php
+++ b/app/Helpers/Docker.php
@@ -1,0 +1,22 @@
+<?php
+namespace App\Helpers;
+
+class Docker 
+{
+    /**
+     * Constructs the docker cp command to copy a file from a Docker container with retries.
+     *
+     * @param string $filePath     The path to the file inside the Docker container.
+     * @param string $fileName      File name.
+     * @return string              The constructed docker cp command.
+     */
+    public function buildDockerCpCommand($filePath, $fileName) {
+        // Set the base docker cp command
+        $command = "docker cp";
+        
+        // Append options to the command
+        $command .= " $filePath wordpress:/var/www/html/$fileName";
+
+        return $command;
+    }
+}

--- a/app/Helpers/EnvUtils.php
+++ b/app/Helpers/EnvUtils.php
@@ -69,7 +69,6 @@ class EnvUtils
      */
     public function checkSQLfileIsValid($filePath)
     {
-
         if (!$this->isSqlFile($filePath)) {
             throw new \InvalidArgumentException("File is not an SQL file type. ");
         }

--- a/app/Helpers/EnvUtils.php
+++ b/app/Helpers/EnvUtils.php
@@ -358,7 +358,8 @@ class EnvUtils
      *
      * @return string The non-production domain for the given target environment.
      */
-    public function getNonProdDomain($target): string {
+    public function getNonProdDomain($target): string
+    {
         return $target === 'local' ?
             'hale.docker' :
             "hale-platform-$target.apps.live.cloud-platform.service.justice.gov.uk";

--- a/app/Helpers/EnvUtils.php
+++ b/app/Helpers/EnvUtils.php
@@ -110,6 +110,11 @@ class EnvUtils
      */
     public function getDomain($env, $blogID = null)
     {
+
+        if ($env === 'local') {
+            return "hale.docker";
+        }
+
         // SSOT hardcoded list of production domains
         // List can be updated in the SiteList.php
         $container = Container::getInstance();
@@ -151,7 +156,6 @@ class EnvUtils
         // Return null if no match
         return null;
     }
-
 
     /**
      * Check if the given filename indicates a multsite database file.
@@ -331,7 +335,7 @@ class EnvUtils
      */
     public function updateCloudPlatformCli()
     {
-        echo "Checking cloud-platform-cli status on the system..." . PHP_EOL;
+        echo "[*] Checking cloud-platform-cli status on the system" . PHP_EOL;
 
         // Execute the Homebrew command to update and upgrade the cloud-platform-cli package
         exec("brew update && brew upgrade cloud-platform-cli 2>/dev/null", $output, $resultCode);
@@ -343,5 +347,20 @@ class EnvUtils
                 "Failed to update and upgrade the cloud-platform-cli package. Exiting."
             );
         }
+    }
+
+    /**
+     * Get the non-production domain based on the target environment.
+     *
+     * This method returns the appropriate non-production domain based on the specified target environment.
+     * If the target is set to 'local', the domain 'hale.docker' is returned. For other non-production environments,
+     * the domain follows the pattern "hale-platform-[TARGET].apps.live.cloud-platform.service.justice.gov.uk".
+     *
+     * @return string The non-production domain for the given target environment.
+     */
+    public function getNonProdDomain($target): string {
+        return $target === 'local' ?
+            'hale.docker' :
+            "hale-platform-$target.apps.live.cloud-platform.service.justice.gov.uk";
     }
 }

--- a/app/Helpers/Kubernetes.php
+++ b/app/Helpers/Kubernetes.php
@@ -135,10 +135,11 @@ class Kubernetes
      * @param string $fileName   The name of the file within the container.
      * @return string            The constructed kubectl cp command.
      */
-    private function buildKubectlCpCommand($target, $filePath, $fileName, $podName, $container) {
+    private function buildKubectlCpCommand($target, $filePath, $fileName, $podName, $container)
+    {
         // Set the base kubectl cp command
         $command = "kubectl cp";
-        
+
         // Append options to the command
         $command .= " --retries=10"; // Adjust the number of retries as needed
         $command .= " -n hale-platform-$target";

--- a/app/Helpers/Wordpress.php
+++ b/app/Helpers/Wordpress.php
@@ -118,4 +118,127 @@ class Wordpress
             );
         }
     }
+
+    /**
+     * Execute a WordPress database query.
+     *
+     * This function executes a WordPress database query using the WP-CLI `wp db query` command 
+     * inside a Kubernetes (or Docker) container.
+     *
+     * @param string $target      The target environment where the command will be executed.
+     * @param array  $arguments   The arguments for the database query command.
+     * @throws InvalidArgumentException If the command execution fails.
+     * @return void
+     */
+    public function executeWordPressDBQuery($target, $arguments) {
+        // Get the Kubernetes exec command for the target environment
+        $containerExec = $this->kubernetesObject->getExecCommand($target);
+    
+        // Set the base WP-CLI command
+        $command = "wp db query";
+    
+        // Construct the full command
+        $fullCommand = "$containerExec $command";
+    
+        // Append arguments to the command
+        if (!empty($arguments)) {
+            $fullCommand .= ' ' . implode(' ', $arguments);
+        }
+        
+        // Execute the command using passthru
+        passthru($fullCommand, $status);
+    
+        // Check if the command failed
+        if ($status !== 0) {
+            // An error occurred, handle it here
+            throw new \InvalidArgumentException(
+                "Error: wp db query failed. Command run: \n$fullCommand"
+            );
+        }
+    }
+
+    /**
+     * Modify the status of a WordPress plugin on a target environment.
+     *
+     * This method modifies the status of a specified WordPress plugin on the given target environment.
+     * The method utilizes Kubernetes exec command to interact with the container environment.
+     * It executes the provided command to enable or disable the plugin.
+     *
+     * @param string $target The target environment where the plugin status will be modified.
+     * @param string $option The action to perform on the plugin ('activate' or 'deactivate').
+     * @param string $pluginName The name of the WordPress plugin to modify.
+     * @param string $nonProdDomain The non-production domain to use for the WordPress instance.
+     * @throws InvalidArgumentException
+     * @return void
+     */
+    public function modifyPluginStatus(string $target, string $option, string $pluginName, string $nonProdDomain): void
+    {
+        // Retrieve the Kubernetes exec command for the target environment
+        $containerExec = $this->kubernetesObject->getExecCommand($target);
+        
+        // Construct the command to execute for modifying the plugin status
+        $command = "$containerExec wp plugin $option $pluginName --url=$nonProdDomain";
+        
+        // Execute the constructed command
+        passthru($command, $status);
+    
+        // Check if the command failed
+        if ($status !== 0) {
+            // An error occurred, handle it here
+            throw new \InvalidArgumentException(
+                "Error: modify plugin failed: \n$command"
+            );
+        }
+    }
+
+        /**
+     * Perform URL replacements in the WordPress database.
+     *
+     * This function performs URL replacements in the WordPress database by updating the 'wp_blogs' table.
+     * It retrieves the target site URL based on the specified target environment, constructs the SQL query,
+     * and executes the query using the WordPressObject's executeWordPressDBQuery method.
+     *
+     * @throws Exception If an error occurs during database query execution.
+     * @return void
+     */
+    public function replaceDatabaseDomain($target, $domain, $blogID)
+    {
+        try {
+            // Construct the SQL query to update the 'wp_blogs' table
+            $arguments = ["'UPDATE wp_blogs SET domain=\"$domain\" WHERE wp_blogs.blog_id=$blogID'"];
+    
+            // Execute the WordPress database query
+            $this->executeWordPressDBQuery($target, $arguments);
+        } catch (Exception $e) {
+            // Handle exceptions (e.g., database query execution error)
+            error_log("Error replacing database domain: " . $e->getMessage());
+            throw $e; // Re-throw the exception to propagate it further
+        }
+    }
+
+    /**
+     * Perform path replacements in the WordPress database.
+     *
+     * This function performs path replacements in the WordPress database by updating the 'wp_blogs' table.
+     * It constructs the SQL query to update the 'path' column to '/' for the specified blog ID and
+     * executes the query using the WordPressObject's executeWordPressDBQuery method.
+     *
+     * @throws Exception If an error occurs during database query execution.
+     * @return void
+     */
+    public function replaceDatabasePath($target, $siteSlug, $blogID)
+    {
+        try {
+            // Construct the SQL query to update the 'wp_blogs' table
+            $arguments = ["'UPDATE wp_blogs SET path=\"/$siteSlug/\" WHERE wp_blogs.blog_id=$blogID'"];
+    
+            // Execute the WordPress database query
+            $this->executeWordPressDBQuery($target, $arguments);
+        } catch (Exception $e) {
+            // Handle exceptions (e.g., database query execution error)
+            error_log("Error replacing database path: " . $e->getMessage());
+            throw $e; // Re-throw the exception to propagate it further
+        }
+    }
+
 }

--- a/app/Helpers/Wordpress.php
+++ b/app/Helpers/Wordpress.php
@@ -122,7 +122,7 @@ class Wordpress
     /**
      * Execute a WordPress database query.
      *
-     * This function executes a WordPress database query using the WP-CLI `wp db query` command 
+     * This function executes a WordPress database query using the WP-CLI `wp db query` command
      * inside a Kubernetes (or Docker) container.
      *
      * @param string $target      The target environment where the command will be executed.
@@ -130,24 +130,25 @@ class Wordpress
      * @throws InvalidArgumentException If the command execution fails.
      * @return void
      */
-    public function executeWordPressDBQuery($target, $arguments) {
+    public function executeWordPressDBQuery($target, $arguments)
+    {
         // Get the Kubernetes exec command for the target environment
         $containerExec = $this->kubernetesObject->getExecCommand($target);
-    
+
         // Set the base WP-CLI command
         $command = "wp db query";
-    
+
         // Construct the full command
         $fullCommand = "$containerExec $command";
-    
+
         // Append arguments to the command
         if (!empty($arguments)) {
             $fullCommand .= ' ' . implode(' ', $arguments);
         }
-        
+
         // Execute the command using passthru
         passthru($fullCommand, $status);
-    
+
         // Check if the command failed
         if ($status !== 0) {
             // An error occurred, handle it here
@@ -175,13 +176,13 @@ class Wordpress
     {
         // Retrieve the Kubernetes exec command for the target environment
         $containerExec = $this->kubernetesObject->getExecCommand($target);
-        
+
         // Construct the command to execute for modifying the plugin status
         $command = "$containerExec wp plugin $option $pluginName --url=$nonProdDomain";
-        
+
         // Execute the constructed command
         passthru($command, $status);
-    
+
         // Check if the command failed
         if ($status !== 0) {
             // An error occurred, handle it here
@@ -206,7 +207,7 @@ class Wordpress
         try {
             // Construct the SQL query to update the 'wp_blogs' table
             $arguments = ["'UPDATE wp_blogs SET domain=\"$domain\" WHERE wp_blogs.blog_id=$blogID'"];
-    
+
             // Execute the WordPress database query
             $this->executeWordPressDBQuery($target, $arguments);
         } catch (Exception $e) {
@@ -231,7 +232,7 @@ class Wordpress
         try {
             // Construct the SQL query to update the 'wp_blogs' table
             $arguments = ["'UPDATE wp_blogs SET path=\"/$siteSlug/\" WHERE wp_blogs.blog_id=$blogID'"];
-    
+
             // Execute the WordPress database query
             $this->executeWordPressDBQuery($target, $arguments);
         } catch (Exception $e) {
@@ -240,5 +241,4 @@ class Wordpress
             throw $e; // Re-throw the exception to propagate it further
         }
     }
-
 }

--- a/app/Providers/SiteList.php
+++ b/app/Providers/SiteList.php
@@ -5,125 +5,143 @@ use Illuminate\Container\Container;
 $container = Container::getInstance();
 
 /**
- * Definitive site list.
+ * Definitive site list that have production domains.
  *
  * This array contains a list of sites with their respective information.
- *
- * Each site is represented by a unique 3-character code as the key, and the value is an array
- * containing the following information:
  *
  * - 'blogID': The ID of the blog.
  * - 'domain': The domain of the site.
  * - 'path': The path of the site.
  */
+
 $sites = [
-    "mag" => [
+    [
         "blogID" => 3,
         "domain" => "magistrates.judiciary.uk",
         "path" => "magistrates",
     ],
 
-    "ccr" => [
+    [
         "blogID" => 5,
         "domain" => "ccrc.gov.uk",
         "path" => "ccrc",
     ],
 
-    "vic" => [
+    [
         "blogID" => 6,
         "domain" => "victimscommissioner.org.uk",
         "path" => "vc",
     ],
 
-    "lob" => [
+    [
         "blogID" => 7,
         "domain" => "layobservers.org",
         "path" => "lo",
     ],
 
-    "cym" => [
+    [
         "blogID" => 11,
         "domain" => "magistrates.judiciary.uk/cymraeg",
         "path" => "cymraeg",
     ],
 
-    "pds" => [
+    [
         "blogID" => 12,
         "domain" => "publicdefenderservice.org.uk",
         "path" => "pds",
     ],
 
-    "imb" => [
+    [
         "blogID" => 13,
         "domain" => "imb.org.uk",
         "path" => "imb",
     ],
 
-    "vaw" => [
+    [
         "blogID" => 15,
         "domain" => "victimandwitnessinformation.org.uk",
         "path" => "vw",
     ],
 
-    "icr" => [
+    [
         "blogID" => 16,
         "domain" => "icrir.independent-inquiry.uk",
         "path" => "icrir",
     ],
 
-    "ppj" => [
+    [
         "blogID" => 18,
         "domain" => "prisonandprobationjobs.gov.uk",
         "path" => "ppj",
     ],
 
-    "npm" => [
+    [
         "blogID" => 23,
         "domain" => "nationalpreventivemechanism.org.uk",
         "path" => "npm",
     ],
 
-    "brh" => [
+    [
         "blogID" => 29,
         "domain" => "brookhouseinquiry.org.uk",
         "path" => "brookhouse",
     ],
 
-    "lwc" => [
+    [
         "blogID" => 30,
         "domain" => "lawcom.gov.uk",
         "path" => "lc",
     ],
 
-    "jjb" => [
+    [
         "blogID" => 31,
         "domain" => "jobs.justice.gov.uk",
         "path" => "jj",
     ],
 
-    "ppo" => [
+    [
+        "blogID" => 33,
+        "domain" => "cym.victimandwitnessinformation.org.uk",
+        "path" => "vwcy",
+    ],
+
+    [
         "blogID" => 34,
         "domain" => "ppo.gov.uk",
         "path" => "ppo",
     ],
 
-    "sif" => [
+    [
         "blogID" => 36,
         "domain" => "sifocc.org",
         "path" => "sifocc",
     ],
 
-    "mib" => [
+    [
         "blogID" => 37,
         "domain" => "my.imb.org.uk",
         "path" => "imbmembers-leg",
     ],
 
-    "mlo" => [
+    [
         "blogID" => 39,
         "domain" => "members.layobservers.org",
         "path" => "layobservers-members",
     ],
-    ];
 
-    $container->instance('sites', $sites);
+    [
+        "blogID" => 40,
+        "domain" => "newfuturesnetwork.gov.uk",
+        "path" => "nfn",
+    ],
+
+    [
+        "blogID" => 42,
+        "domain" => "omagh.independent-inquiry.uk",
+        "path" => "omagh",
+    ]
+
+];
+
+
+$container->instance('sites', $sites);

--- a/install.sh
+++ b/install.sh
@@ -40,7 +40,7 @@ then
 fi
 
 # Build binary of latest worm
-php worm app:build --build-version=0.7.0 --no-interaction
+php worm app:build --build-version=0.6.0 --no-interaction
 
 # System link to add build to local $PATH
 sudo ln -s $dir/builds/worm /usr/local/bin/worm

--- a/install.sh
+++ b/install.sh
@@ -40,7 +40,7 @@ then
 fi
 
 # Build binary of latest worm
-php worm app:build --build-version=0.5.0 --no-interaction
+php worm app:build --build-version=0.7.0 --no-interaction
 
 # System link to add build to local $PATH
 sudo ln -s $dir/builds/worm /usr/local/bin/worm


### PR DESCRIPTION
* Allows you to import a database to your local Docker built (either single site or whole multisite)
* Allows you to import a database to the CP environments (except to prod).
* Fixes bug, adding rewrite to HOME and SITE_URL db entries missing from import.
* Prevented import to prod. I thought this might be a bad idea (at least until we test it out thoroughly) but we can discuss.
* Some tidying