### PR TITLE
Add migrateUsers param to migrate command

### DIFF
--- a/app/Commands/MigrateCommand.php
+++ b/app/Commands/MigrateCommand.php
@@ -309,6 +309,7 @@ class MigrateCommand extends Command
 
         // Delete SQL file from the container
         $this->deleteSqlFileFromContainer($source, $sqlFile);
+
         // Copy SQL file from the local machine to the target container
         $this->copySqlFileToContainer($target, $sqlFile);
 
@@ -336,6 +337,7 @@ class MigrateCommand extends Command
 
         // Update s3 bucket media assets, docs, images, etc. with the target environment
         $this->syncS3BucketWithTarget($source, $target, $blogID);
+
         // Migration completed successfully
         $this->info("Migration $typeOfMigration complete 🐛. " . ucfirst($source) . " has been migrated to " . ucfirst($target));
     }

--- a/app/Commands/MigrateCommand.php
+++ b/app/Commands/MigrateCommand.php
@@ -447,7 +447,7 @@ class MigrateCommand extends Command
         }
 
         return $this->task("=> Export multisite database", function () use ($containerExecCommand, $sqlFile, $excludeTables) {
-            $command = "$containerExecCommand wp db export --porcelain $sqlFile " . $excludeTables;
+            $command = "$containerExecCommand wp db export --porcelain $sqlFile $excludeTables";
             $output = shell_exec($command);
         });
     }

--- a/app/Commands/MigrateCommand.php
+++ b/app/Commands/MigrateCommand.php
@@ -309,7 +309,6 @@ class MigrateCommand extends Command
 
         // Delete SQL file from the container
         $this->deleteSqlFileFromContainer($source, $sqlFile);
-        
         // Copy SQL file from the local machine to the target container
         $this->copySqlFileToContainer($target, $sqlFile);
 
@@ -337,7 +336,6 @@ class MigrateCommand extends Command
 
         // Update s3 bucket media assets, docs, images, etc. with the target environment
         $this->syncS3BucketWithTarget($source, $target, $blogID);
-        
         // Migration completed successfully
         $this->info("Migration $typeOfMigration complete 🐛. " . ucfirst($source) . " has been migrated to " . ucfirst($target));
     }
@@ -442,10 +440,8 @@ class MigrateCommand extends Command
 
         $excludeTables = '';
 
-        $excludeTables = '--exclude_tables=wp_users,wp_usermeta';
-
-        if ($this->migrateUsers == 'true') {
-            $excludeTables = '';
+        if ($this->migrateUsers == 'false') {
+            $excludeTables = '--exclude_tables=wp_users,wp_usermeta';
         }
 
         return $this->task("=> Export multisite database", function () use ($containerExecCommand, $sqlFile, $excludeTables) {

--- a/app/Commands/MigrateCommand.php
+++ b/app/Commands/MigrateCommand.php
@@ -15,7 +15,8 @@ class MigrateCommand extends Command
      */
     protected $signature = 'migrate { source : Environment you are migrating from } { target : Environment you are migrating to }
                             {--blogID= : Blog ID of single site you wish to migrate }
-                            {--keepProdDomain= : Keep production domain even if migrating to non-prod env (true or false)}';
+                            {--keepProdDomain= : Keep production domain even if migrating to non-prod env (true or false)}
+                            {--migrateUsers= : For a whole multisite migration should users be migrated. Users are not migrated by default, (true or false)}';
 
     /**
      * The description of the command.
@@ -103,6 +104,13 @@ class MigrateCommand extends Command
      */
     protected $keepProdDomain;
 
+     /**
+     * Should User DB Tables be migrated
+     *
+     * @var bool|false
+     */
+    protected $migrateUsers;
+
     /**
      * Execute the console command.
      *
@@ -115,6 +123,7 @@ class MigrateCommand extends Command
         $this->target = $this->argument('target');
         $this->blogID = is_numeric($this->option('blogID')) ? $this->option('blogID') : null;
         $this->keepProdDomain = $this->option('keepProdDomain') ? $this->option('keepProdDomain') : null;
+        $this->migrateUsers = $this->option('migrateUsers') ? $this->option('migrateUsers') : 'false';
 
         // Set namespace and file naming
         $this->sourceNamespace = "hale-platform-$this->source";
@@ -300,7 +309,7 @@ class MigrateCommand extends Command
 
         // Delete SQL file from the container
         $this->deleteSqlFileFromContainer($source, $sqlFile);
-
+        
         // Copy SQL file from the local machine to the target container
         $this->copySqlFileToContainer($target, $sqlFile);
 
@@ -328,7 +337,7 @@ class MigrateCommand extends Command
 
         // Update s3 bucket media assets, docs, images, etc. with the target environment
         $this->syncS3BucketWithTarget($source, $target, $blogID);
-
+        
         // Migration completed successfully
         $this->info("Migration $typeOfMigration complete 🐛. " . ucfirst($source) . " has been migrated to " . ucfirst($target));
     }
@@ -431,8 +440,16 @@ class MigrateCommand extends Command
     {
         $containerExecCommand = $this->getExecCommand($env);
 
-        return $this->task("=> Export multisite database", function () use ($containerExecCommand, $sqlFile) {
-            $command = "$containerExecCommand wp db export --porcelain $sqlFile --exclude_tables=wp_users,wp_usermeta";
+        $excludeTables = '';
+
+        $excludeTables = '--exclude_tables=wp_users,wp_usermeta';
+
+        if ($this->migrateUsers == 'true') {
+            $excludeTables = '';
+        }
+
+        return $this->task("=> Export multisite database", function () use ($containerExecCommand, $sqlFile, $excludeTables) {
+            $command = "$containerExecCommand wp db export --porcelain $sqlFile " . $excludeTables;
             $output = shell_exec($command);
         });
     }

--- a/app/Commands/MigrateCommand.php
+++ b/app/Commands/MigrateCommand.php
@@ -432,7 +432,7 @@ class MigrateCommand extends Command
         $containerExecCommand = $this->getExecCommand($env);
 
         return $this->task("=> Export multisite database", function () use ($containerExecCommand, $sqlFile) {
-            $command = "$containerExecCommand wp db export --porcelain $sqlFile";
+            $command = "$containerExecCommand wp db export --porcelain $sqlFile --exclude_tables=wp_users,wp_usermeta";
             $output = shell_exec($command);
         });
     }


### PR DESCRIPTION
The migrateUsers param controls if the user tables are migrated. By default the tables are excluded.